### PR TITLE
Fix exit code

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,11 @@
-use crate::version::VERSION;
 use reqwest::{Client, ClientBuilder};
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const NAME: &str = env!("CARGO_PKG_NAME");
 
 pub fn client() -> Client {
   ClientBuilder::new()
-      .user_agent(format!("appsignal-wrap/{}", VERSION))
+      .user_agent(format!("{NAME}/{VERSION}"))
       .build()
       .unwrap()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod log;
 
 mod client;
 mod timestamp;
-mod version;
 mod ndjson;
 mod hostname;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,1 +1,0 @@
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
... and other small improvements. Fixes #1.

### [Exit with the child process' exit code](https://github.com/appsignal/appsignal-wrap/commit/30ae5bea1eb3b77467e0856b310940072b99e698)

If the child process exits with an exit code, exit with that exit
code.

If the child process does not exit with an exit code (meaning that
its exit was caused by a signal) then add 128 to the code of the
signal that caused the exit and use that as the exit code. This is
how shells represent signal exit statuses.

### [Reset log interval when sending full batch](https://github.com/appsignal/appsignal-wrap/commit/3c0668bc53f757c17aeed51dd139ca8e9d6b99b1)

Usually, logs are sent in batches every ten seconds, unless the
buffer for the batch grows too big, which triggers it to be
sent immediately.

When this happen, reset the ten second interval, so that it waits
another ten seconds before sending a not-too-big batch.

### [Get the user agent name from the package](https://github.com/appsignal/appsignal-wrap/commit/6e841836c757e85c94926b0fca949705be2c047b)

We might rename it at some point soon.