### PR TITLE
Fix log timestamps

### DIFF
--- a/src/check_in.rs
+++ b/src/check_in.rs
@@ -95,7 +95,7 @@ impl HeartbeatConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::timestamp::tests::{TestTimestamp, EXPECTED_SECS};
+    use crate::timestamp::tests::{timestamp, EXPECTED_SECS};
 
     fn check_in_config() -> CheckInConfig {
         CheckInConfig {
@@ -112,7 +112,7 @@ mod tests {
             digest: "some-digest".to_string(),
         };
 
-        let request = config.request(&mut TestTimestamp, CronKind::Start).unwrap();
+        let request = config.request(&mut timestamp(), CronKind::Start).unwrap();
 
         assert_eq!(request.method().as_str(), "POST");
         assert_eq!(
@@ -137,7 +137,7 @@ mod tests {
             check_in: check_in_config(),
         };
 
-        let request = config.request(&mut TestTimestamp).unwrap();
+        let request = config.request(&mut timestamp()).unwrap();
 
         assert_eq!(request.method().as_str(), "POST");
         assert_eq!(

--- a/src/log.rs
+++ b/src/log.rs
@@ -109,7 +109,7 @@ pub enum LogSeverity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::timestamp::tests::{TestTimestamp, EXPECTED_RFC3339};
+    use crate::timestamp::tests::{timestamp, EXPECTED_RFC3339};
 
     fn log_config() -> LogConfig {
         LogConfig {
@@ -127,13 +127,13 @@ mod tests {
         let config = log_config();
         let first_message = LogMessage::new(
             &config,
-            &mut TestTimestamp,
+            &mut timestamp(),
             LogSeverity::Info,
             "first-message".to_string(),
         );
         let second_message = LogMessage::new(
             &config,
-            &mut TestTimestamp,
+            &mut timestamp(),
             LogSeverity::Error,
             "second-message".to_string(),
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use std::{
     io,
     io::{stderr, stdout, Write},
 };
+use timestamp::MonotonicTimestamp;
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::{Child, Command};
 use tokio::select;
@@ -166,6 +167,8 @@ async fn log_loop(
     mut stdout: Option<UnboundedReceiver<Option<String>>>,
     mut stderr: Option<UnboundedReceiver<Option<String>>>,
 ) {
+    let mut timestamp = MonotonicTimestamp::new(SystemTimestamp);
+
     if stdout.is_none() && stderr.is_none() {
         return;
     }
@@ -193,7 +196,7 @@ async fn log_loop(
                         }
                     }
                     Some(line) => {
-                        messages.push(LogMessage::new(&log, &mut SystemTimestamp, LogSeverity::Info, line));
+                        messages.push(LogMessage::new(&log, &mut timestamp, LogSeverity::Info, line));
                     }
                 }
             }
@@ -207,7 +210,7 @@ async fn log_loop(
                         }
                     }
                     Some(line) => {
-                        messages.push(LogMessage::new(&log, &mut SystemTimestamp, LogSeverity::Error, line));
+                        messages.push(LogMessage::new(&log, &mut timestamp, LogSeverity::Error, line));
                     }
                 }
             }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, SecondsFormat};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+#[derive(Clone, Copy)]
 pub struct SystemTimestamp;
 
 impl Timestamp for SystemTimestamp {
@@ -8,6 +9,40 @@ impl Timestamp for SystemTimestamp {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("failed to get system time")
+    }
+}
+
+const MONOTONIC_GAP: Duration = Duration::from_millis(1);
+
+pub struct MonotonicTimestamp<T: Timestamp> {
+    last: Option<Duration>,
+    source: T,
+}
+
+impl<T: Timestamp> MonotonicTimestamp<T> {
+    pub fn new(source: T) -> Self {
+        Self { last: None, source }
+    }
+
+    #[cfg(test)]
+    pub fn swap(&mut self, source: T) {
+        self.source = source;
+    }
+}
+
+impl<T: Timestamp> Timestamp for MonotonicTimestamp<T> {
+    fn now(&mut self) -> Duration {
+        let now = self.source.now();
+
+        self.last = Some(match self.last {
+            Some(last) => match now.checked_sub(last) {
+                Some(diff) if diff > MONOTONIC_GAP => now,
+                _ => last + MONOTONIC_GAP,
+            },
+            None => now,
+        });
+
+        self.last.unwrap()
     }
 }
 
@@ -32,14 +67,61 @@ pub trait Timestamp {
 pub mod tests {
     use super::*;
 
-    pub struct TestTimestamp;
+    pub struct TestTimestamp(Duration);
 
     impl Timestamp for TestTimestamp {
         fn now(&mut self) -> Duration {
-            Duration::from_secs(1_000_000_000)
+            self.0
         }
+    }
+
+    pub fn timestamp() -> TestTimestamp {
+        TestTimestamp(Duration::from_secs(1_000_000_000))
     }
 
     pub const EXPECTED_SECS: u64 = 1_000_000_000;
     pub const EXPECTED_RFC3339: &str = "2001-09-09T01:46:40.000Z";
+
+    #[test]
+    fn monotonic_timestamp() {
+        // If the source time stays the same between calls,
+        // it should increase monotonically from the last time by the gap.
+        let mut monotonic = MonotonicTimestamp::new(TestTimestamp(Duration::from_millis(1_000)));
+
+        assert_eq!(monotonic.now().as_millis(), 1_000);
+        assert_eq!(monotonic.now().as_millis(), 1_001);
+        assert_eq!(monotonic.now().as_millis(), 1_002);
+
+        // If the source time is greater than the last time,
+        // it should increase to the new source time.
+        monotonic.swap(TestTimestamp(Duration::from_millis(1_500)));
+
+        assert_eq!(monotonic.now().as_millis(), 1_500);
+        assert_eq!(monotonic.now().as_millis(), 1_501);
+        assert_eq!(monotonic.now().as_millis(), 1_502);
+
+        // If the source time is smaller than the last time,
+        // it should increase monotonically from the last time by the gap.
+        monotonic.swap(TestTimestamp(Duration::from_millis(1_000)));
+
+        assert_eq!(monotonic.now().as_millis(), 1_503);
+        assert_eq!(monotonic.now().as_millis(), 1_504);
+        assert_eq!(monotonic.now().as_millis(), 1_505);
+
+        // Source is one gap below the last time (two gaps below the next time)
+        monotonic.swap(TestTimestamp(Duration::from_millis(1_504)));
+        assert_eq!(monotonic.now().as_millis(), 1_506);
+
+        // Source is at the last time (one gap below the next time)
+        monotonic.swap(TestTimestamp(Duration::from_millis(1_506)));
+        assert_eq!(monotonic.now().as_millis(), 1_507);
+
+        // Source is one gap above the last time (at the next time)
+        monotonic.swap(TestTimestamp(Duration::from_millis(1_508)));
+        assert_eq!(monotonic.now().as_millis(), 1_508);
+
+        // Source is two gaps above the last time (one gap above the next time)
+        monotonic.swap(TestTimestamp(Duration::from_millis(1_510)));
+        assert_eq!(monotonic.now().as_millis(), 1_510);
+    }
 }


### PR DESCRIPTION
This PR builds on the changes in #13. See linked commit for diff.

Fixes #7.

### [Increase log timestamps monotonically](https://github.com/appsignal/appsignal-wrap/commit/b71522d2a2eb77f796d391319588005c5e803521)

The precision of log timestamps is by millisecond, which results in
log lines received in the same millisecond being shown out of order
in the AppSignal UI. To prevent this, ensure that the timestamps
included in log messages are at least one millisecond apart from
each other.