### PR TITLE
Restore default (ignore) Rust SIGPIPE behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use crate::cli::Cli;
 use crate::client::client;
 use crate::log::{LogConfig, LogMessage, LogSeverity};
 use crate::package::NAME;
-use crate::signals::{has_terminating_intent, reset_sigpipe, signal_stream};
+use crate::signals::{has_terminating_intent, signal_stream};
 use crate::timestamp::SystemTimestamp;
 
 use ::log::{debug, error, trace};
@@ -38,8 +38,6 @@ use clap::Parser;
 use env_logger::Env;
 
 fn main() {
-    reset_sigpipe();
-
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(|buf, record| {
             let level = record.level().to_string().to_ascii_lowercase();


### PR DESCRIPTION
Remove `reset_sigpipe` and other code that handles `SIGPIPE` in any way, such as ignoring it or forwarding it to the child process.

This restores the default behaviour of the Rust standard library, which is to always ignore the signal. This behaviour will be inherited by the child process.

See #12 for context.