### PR TITLE
Install script in release

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -70,6 +70,7 @@ jobs:
             'release/x86_64-unknown-linux-gnu.tar.gz#Linux (x86_64)' \
             'release/x86_64-unknown-linux-musl.tar.gz#Linux (x86_64, musl)' \
             'release/aarch64-unknown-linux-gnu.tar.gz#Linux (arm64)' \
-            'release/aarch64-unknown-linux-musl.tar.gz#Linux (arm64, musl)'
+            'release/aarch64-unknown-linux-musl.tar.gz#Linux (arm64, musl)' \
+            'release/install.sh#Installer script'
         env:
           GH_TOKEN: ${{github.token}}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 The easiest way to get `appsignal-wrap` in your machine is to run our installation one-liner:
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/appsignal/appsignal-wrap/refs/heads/main/install.sh | sh
+curl -sSL https://github.com/appsignal/appsignal-wrap/releases/latest/download/install.sh | sh
 ```
 
 You'll need to run it with super-user privileges -- if you're not running this as root, prefix it with `sudo`.

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,9 @@ if ! command -v tar >/dev/null; then
   exit 1
 fi
 
-VERSION="${APPSIGNAL_WRAP_VERSION:-"latest"}"
+LAST_RELEASE="0.1.1"
+
+VERSION="${APPSIGNAL_WRAP_VERSION:-"$LAST_RELEASE"}"
 INSTALL_FOLDER="${APPSIGNAL_WRAP_INSTALL_FOLDER:-"/usr/local/bin"}"
 
 # Expected values are "linux" or "darwin".

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,7 @@ if [ "$OS" = "linux" ]; then
     EXTRA="musl"
     EXTRA_FRIENDLY="musl"
   else
+    # Do not add "gnu" to the friendly triple, as it is the assumed default.
     EXTRA="gnu"
   fi
 fi
@@ -74,18 +75,20 @@ else
 fi
 
 if [ -z "$EXTRA_FRIENDLY" ]; then
-  FRIENDLY="${OS_FRIENDLY} (${ARCH_FRIENDLY})"
+  TRIPLE_FRIENDLY="${OS_FRIENDLY} (${ARCH_FRIENDLY})"
 else
-  FRIENDLY="${OS_FRIENDLY} (${ARCH_FRIENDLY}, ${EXTRA_FRIENDLY})"
+  TRIPLE_FRIENDLY="${OS_FRIENDLY} (${ARCH_FRIENDLY}, ${EXTRA_FRIENDLY})"
 fi
-
-echo "Downloading $VERSION version of the \`appsignal-wrap\` binary for $FRIENDLY..."
 
 if [ "$VERSION" = "latest" ]; then
   URL="https://github.com/appsignal/appsignal-wrap/releases/latest/download/$TRIPLE.tar.gz"
+  VERSION_FRIENDLY="latest version"
 else
   URL="https://github.com/appsignal/appsignal-wrap/releases/download/v$VERSION/$TRIPLE.tar.gz"
+  VERSION_FRIENDLY="version $VERSION"
 fi
+
+echo "Downloading $VERSION_FRIENDLY of the \`appsignal-wrap\` binary for $TRIPLE_FRIENDLY..."
 
 curl --progress-bar -SL "$URL" | tar -C "$INSTALL_FOLDER" -xz
 

--- a/script/build_artifacts
+++ b/script/build_artifacts
@@ -6,3 +6,5 @@ script/build_artifact x86_64-unknown-linux-gnu
 script/build_artifact x86_64-unknown-linux-musl
 script/build_artifact aarch64-unknown-linux-gnu
 script/build_artifact aarch64-unknown-linux-musl
+
+cp install.sh release/

--- a/script/write_version
+++ b/script/write_version
@@ -7,3 +7,8 @@ File.write(
   "Cargo.toml",
   File.read("Cargo.toml").sub(/^version = ".*"$/, %(version = "#{VERSION}"))
 )
+
+File.write(
+  "install.sh",
+  File.read("install.sh").sub(/^LAST_RELEASE=".*"$/, %(LAST_RELEASE="#{VERSION}"))
+)


### PR DESCRIPTION
[skip changeset] -- will merge without review.

### [Add installation script to release](https://github.com/appsignal/appsignal-wrap/commit/79aa21156d413abb26e7e2217e819332f67444e6)

Currently, the installation script referenced in the README.md is
the one currently available in the `main` branch. This means that,
if we were to change the installation script in the `main` branch,
in concordance with a different change that was not yet released,
the README would point to an installation script that might not
work correctly with the latest release.

To fix this, make the installation script part of the release
itself.

### [Hardcode version number in install script](https://github.com/appsignal/appsignal-wrap/commit/07dbc5bfd5656ebddae0b829969d4c2ecf9470a4)

Since the installation script for each release will now be part of
the release itself, it makes sense for the installation script to
attempt to install the release that it was part of, rather than the
latest available release.

### [Improve install script version output](https://github.com/appsignal/appsignal-wrap/commit/a777d97c322e93beb14ee50a8cf36b4071b61bea)

Say "latest version" if `APPSIGNAL_WRAP_VERSION=latest`, but
otherwise say "version 0.1.1". Less Yoda-esque.