### PR TITLE
Rename to AppSignal Wrap

### DIFF
--- a/.changesets/rename-the-application-to--appsignal-wrap-.md
+++ b/.changesets/rename-the-application-to--appsignal-wrap-.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Rename the application to `appsignal-wrap`. A symlink to the previous `appsignal-run` name is created during installation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# `appsignal-run` changelog
+# `appsignal-wrap` changelog
 
 ## 0.2.2
 
@@ -6,7 +6,7 @@ _Published on 2024-12-09._
 
 ### Changed
 
-- Rename the project to `appsignal-run`. (patch [743f35e](https://github.com/appsignal/appsignal-run/commit/743f35e9479c911432adc921eeacfeeddd0815f6))
+- Rename the project to `appsignal-run`. (patch [743f35e](https://github.com/appsignal/appsignal-wrap/commit/743f35e9479c911432adc921eeacfeeddd0815f6))
 
 ## 0.2.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,8 +91,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "appsignal-run"
-version = "0.2.1"
+name = "appsignal-wrap"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "appsignal-run"
+name = "appsignal-wrap"
 version = "0.2.2"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# `appsignal-run`: monitor any process with AppSignal
+# `appsignal-wrap`: monitor any process with AppSignal
 
-`appsignal-run` is a tool that allows you to monitor any process with AppSignal. You can use it to:
+`appsignal-wrap` is a tool that allows you to monitor any process with AppSignal. You can use it to:
 
 - Send the process' standard output and standard error as logs to AppSignal, to be able to troubleshoot issues.
 - Send a start cron check-in to AppSignal when the process starts, and a finish cron check-in if it finishes successfully, to be able to track whether it runs successfully and on schedule.
@@ -8,27 +8,27 @@
 
 ## Installation
 
-The easiest way to get `appsignal-run` in your machine is to run our installation one-liner:
+The easiest way to get `appsignal-wrap` in your machine is to run our installation one-liner:
 
 ```sh
-curl -sSL https://github.com/appsignal/appsignal-run/releases/latest/download/install.sh | sh
+curl -sSL https://github.com/appsignal/appsignal-wrap/releases/latest/download/install.sh | sh
 ```
 
 You'll need to run it with super-user privileges -- if you're not running this as root, prefix it with `sudo`.
 
-`appsignal-run` is only supported for Linux and macOS, in the x86_64 (Intel) and arm64 (Apple Silicon) architectures. Linux distributions based on musl, such as Alpine, are also supported.
+`appsignal-wrap` is only supported for Linux and macOS, in the x86_64 (Intel) and arm64 (Apple Silicon) architectures. Linux distributions based on musl, such as Alpine, are also supported.
 
-Not a fan of `curl | sh` one-liners? Download the binary for your operating system and architecture [from our latest release](https://github.com/appsignal/appsignal-run/releases/latest/).
+Not a fan of `curl | sh` one-liners? Download the binary for your operating system and architecture [from our latest release](https://github.com/appsignal/appsignal-wrap/releases/latest/).
 
 ## Usage
 
-See `appsignal-run --help` for detailed information on all configuration options.
+See `appsignal-wrap --help` for detailed information on all configuration options.
 
 ```
-appsignal-run NAME [OPTIONS] -- COMMAND
+appsignal-wrap NAME [OPTIONS] -- COMMAND
 ```
 
-To use `appsignal-run`, you must provide an app-level API key. You can find the app-level API key in the [push and deploy settings](https://appsignal.com/redirect-to/app?to=api_keys) for your application.
+To use `appsignal-wrap`, you must provide an app-level API key. You can find the app-level API key in the [push and deploy settings](https://appsignal.com/redirect-to/app?to=api_keys) for your application.
 
 To provide the app-level API key, set it as the value for the `APPSIGNAL_APP_PUSH_API_KEY` environment variable, or pass it as the value for the `--api-key` command-line option.
 
@@ -38,10 +38,10 @@ Finally, you must provide a command to execute as the last argument, preceded by
 
 ### Send standard output and error as logs to AppSignal
 
-By default, `appsignal-run` will send the standard output and standard error of the command it executes as logs to AppSignal:
+By default, `appsignal-wrap` will send the standard output and standard error of the command it executes as logs to AppSignal:
 
 ```sh
-appsignal-run sync_customers -- python ./sync_customers.py
+appsignal-wrap sync_customers -- python ./sync_customers.py
 ```
 
 The above command will execute `python ./sync_customers.py` with the AppSignal runner, sending its standard output and error as logs to AppSignal.
@@ -50,10 +50,10 @@ You can disable sending logs entirely by using the `--no-log` command-line optio
 
 ### Report failure exit codes as errors to AppSignal
 
-By default, `appsignal-run` will report an error to AppSignal if the command it executes exits with a failure exit code, or if the command fails to be executed:
+By default, `appsignal-wrap` will report an error to AppSignal if the command it executes exits with a failure exit code, or if the command fails to be executed:
 
 ```sh
-appsignal-run sync_customers -- python ./sync_customers.py
+appsignal-wrap sync_customers -- python ./sync_customers.py
 ```
 
 The above command will attempt to execute `python ./sync_customers.py` with the AppSignal runner, and it will report an error to AppSignal if it fails to execute the command, or if the command ends with a failure exit code.
@@ -65,7 +65,7 @@ You can disable sending errors entirely by using the `--no-error` command-line o
 Use the `--heartbeat` flag to send heartbeat check-ins continuously to AppSignal, for as long as the process is running. This allows you to track that certain processes are always up:
 
 ```sh
-appsignal-run worker --heartbeat -- bundle exec ruby ./worker.rb
+appsignal-wrap worker --heartbeat -- bundle exec ruby ./worker.rb
 ```
 
 The above command will execute `bundle exec ruby ./worker.rb`, and send heartbeat check-ins to AppSignal with the `worker` check-in identifier continuously, for as long as the process is running.
@@ -77,7 +77,7 @@ It will also send logs and report errors, as described in previous sections. To 
 Use the `--cron` flag to send a start cron check-in to AppSignal when the process starts, and a finish cron check-in to AppSignal if it finishes successfully. This allows you to track that certain processes are executed on schedule:
 
 ```sh
-appsignal-run sync_customers --cron -- python ./sync_customers.py
+appsignal-wrap sync_customers --cron -- python ./sync_customers.py
 ```
 
 The above command will execute `python ./sync_customers.py`, send a start cron check-in to AppSignal with the `sync_customers` check-in identifier if it starts successfully, and send a finish cron check-in to AppSignal if it finishes with a success exit code.
@@ -90,10 +90,10 @@ It will also send logs and report errors, as described in previous sections. To 
 
 You can use the `--heartbeat` command-line option to send heartbeat check-ins (named `database` in this example) to AppSignal periodically, for as long as the database process is running. This allows you to set up alerts that will notify you if the database is no longer running.
 
-In this example, we'll start `mysqld`, the MySQL server process, using `appsignal-run`:
+In this example, we'll start `mysqld`, the MySQL server process, using `appsignal-wrap`:
 
 ```sh
-appsignal-run database --heartbeat -- mysqld
+appsignal-wrap database --heartbeat -- mysqld
 ```
 
 This invocation can then be added to the `mysql.service` service definition:
@@ -102,13 +102,13 @@ This invocation can then be added to the `mysql.service` service definition:
 # /usr/lib/systemd/system/mysql.service
 
 [Service]
-# Modify the existing ExecStart line to add `appsignal-run`
-ExecStart=/usr/local/bin/appsignal-run database --heartbeat -- /usr/sbin/mysqld
+# Modify the existing ExecStart line to add `appsignal-wrap`
+ExecStart=/usr/local/bin/appsignal-wrap database --heartbeat -- /usr/sbin/mysqld
 # Add an environment variable containing the AppSignal app-level push API key
 Environment=APPSIGNAL_APP_PUSH_API_KEY=...
 ```
 
-In addition to sending heartbeat check-ins, by default `appsignal-run` will also: 
+In addition to sending heartbeat check-ins, by default `appsignal-wrap` will also: 
 
 - Send your database process' standard output and standard error as logs to AppSignal, under the `database` group
 - Report failure exit codes as errors to AppSignal, grouped under the `database` action
@@ -119,10 +119,10 @@ You can use the `--no-log` and `--no-error` command-line option to disable this 
 
 You can use the `--cron` command-line option to send cron check-ins (named `backup` in this example) to notify AppSignal when your cron job starts, and when it finishes, if and only if it finishes successfully.
 
-In this example, we'll run `/usr/local/bin/backup.sh`, our custom backup shell script, using `appsignal-run`:
+In this example, we'll run `/usr/local/bin/backup.sh`, our custom backup shell script, using `appsignal-wrap`:
 
 ```sh
-appsignal-run backup --cron -- bash /usr/local/bin/backup.sh
+appsignal-wrap backup --cron -- bash /usr/local/bin/backup.sh
 ```
 
 This invocation can then be added to the `/etc/crontab` file:
@@ -132,10 +132,10 @@ This invocation can then be added to the `/etc/crontab` file:
 
 APPSIGNAL_APP_PUSH_API_KEY=...
 
-0 2 * * * appsignal-run backup --cron -- bash /usr/local/bin/backup.sh
+0 2 * * * appsignal-wrap backup --cron -- bash /usr/local/bin/backup.sh
 ```
 
-In addition to sending cron check-ins, by default `appsignal-run` will also: 
+In addition to sending cron check-ins, by default `appsignal-wrap` will also: 
 
 - Send your database process' standard output and standard error as logs to AppSignal, under the `backup` group
 - Report failure exit codes as errors to AppSignal, grouped under the `backup` action

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,12 @@
 set -eu
 
 if ! command -v curl >/dev/null; then
-  echo "Error: \`curl\` is required to download the \`appsignal-run\` binary"
+  echo "Error: \`curl\` is required to download the \`appsignal-wrap\` binary"
   exit 1
 fi
 
 if ! command -v tar >/dev/null; then
-  echo "Error: \`tar\` is required to extract the \`appsignal-run\` binary"
+  echo "Error: \`tar\` is required to extract the \`appsignal-wrap\` binary"
   exit 1
 fi
 
@@ -84,15 +84,15 @@ else
 fi
 
 if [ "$VERSION" = "latest" ]; then
-  URL="https://github.com/appsignal/appsignal-run/releases/latest/download/$TRIPLE.tar.gz"
+  URL="https://github.com/appsignal/appsignal-wrap/releases/latest/download/$TRIPLE.tar.gz"
   VERSION_FRIENDLY="latest version"
 else
-  URL="https://github.com/appsignal/appsignal-run/releases/download/v$VERSION/$TRIPLE.tar.gz"
+  URL="https://github.com/appsignal/appsignal-wrap/releases/download/v$VERSION/$TRIPLE.tar.gz"
   VERSION_FRIENDLY="version $VERSION"
 fi
 
-echo "Downloading $VERSION_FRIENDLY of the \`appsignal-run\` binary for $TRIPLE_FRIENDLY..."
+echo "Downloading $VERSION_FRIENDLY of the \`appsignal-wrap\` binary for $TRIPLE_FRIENDLY..."
 
 curl --progress-bar -SL "$URL" | tar -C "$INSTALL_FOLDER" -xz
 
-echo "Done! Installed \`appsignal-run\` binary at \`$INSTALL_FOLDER/appsignal-run\`."
+echo "Done! Installed \`appsignal-wrap\` binary at \`$INSTALL_FOLDER/appsignal-wrap\`."

--- a/install.sh
+++ b/install.sh
@@ -95,4 +95,10 @@ echo "Downloading $VERSION_FRIENDLY of the \`appsignal-wrap\` binary for $TRIPLE
 
 curl --progress-bar -SL "$URL" | tar -C "$INSTALL_FOLDER" -xz
 
+# Remove the old `appsignal-run` binary or symlink if it exists.
+rm -f "$INSTALL_FOLDER/appsignal-run" || true
+# Create a new `appsignal-run` symlink to the `appsignal-wrap` binary.
+# This is done to maintain backwards compatibility with the previous name.
+ln -s "$INSTALL_FOLDER/appsignal-wrap" "$INSTALL_FOLDER/appsignal-run"
+
 echo "Done! Installed \`appsignal-wrap\` binary at \`$INSTALL_FOLDER/appsignal-wrap\`."

--- a/mono.yml
+++ b/mono.yml
@@ -1,6 +1,6 @@
 ---
 language: "custom"
-repo: "https://github.com/appsignal/appsignal-run"
+repo: "https://github.com/appsignal/appsignal-wrap"
 build:
   command: "echo 'Can only build from GitHub Actions'"
 publish:

--- a/script/build_artifact
+++ b/script/build_artifact
@@ -11,7 +11,7 @@ echo "Building for \`$TARGET\`..."
 echo
 
 cross build --release --target $TARGET
-tar -czvf release/$TARGET.tar.gz -C target/$TARGET/release appsignal-run
+tar -czvf release/$TARGET.tar.gz -C target/$TARGET/release appsignal-wrap
 
 echo "Done! Built release at \`release/$TARGET.tar.gz\`."
 echo


### PR DESCRIPTION
### [Rename appsignal-run to appsignal-wrap](https://github.com/appsignal/appsignal-run/commit/7e53e89d8a9224edb002ae82bcc56af822284e64)

### [Add symlink for the previous name](https://github.com/appsignal/appsignal-run/commit/cb927377f4060e54fad37561f907cedb456497ee)

Since we've released this with the previous name and customers may
have set up scripting that relies on the previous name, set up a
symlink from the previous name to the current name during the
installation process.