### PR TITLE
Fix exit with parent on macOS

### DIFF
--- a/.changesets/fix-exit-with-parent-on-macos.md
+++ b/.changesets/fix-exit-with-parent-on-macos.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix exit with parent on macOS. Previously, when the parent process was terminated by a signal which could not be caught, such as `SIGSTOP` or `SIGKILL`, the child process was not terminated on macOS.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "appsignal-wrap"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "clap",

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -18,9 +18,100 @@ fn set_exit_with_parent() {
 
 #[cfg(target_os = "macos")]
 fn set_exit_with_parent() {
-    // macOS does not have the `prctl` function, so we do nothing.
-    // This means that the child process will not be terminated when
-    // the parent process exits.
+    // macOS lacks `prctl`, so we use `kqueue`/`kevent` with `EVFILT_PROC`/`NOTE_EXIT`
+    // to watch for the parent process exiting.
+    //
+    // Because this runs in `pre_exec` (after fork, before exec), any thread we spawn
+    // would be killed by the subsequent `exec` call. Instead, we double-fork a detached
+    // watcher process: the intermediate process exits immediately (so the watcher is
+    // re-parented to PID 1), and the watcher blocks on `kevent` until either the parent
+    // or the child exits.
+    use libc::{c_int, close, fork, getpid, getppid, kevent, kqueue, pid_t, waitpid};
+    use libc::{EVFILT_PROC, EV_ADD, EV_ENABLE, NOTE_EXIT, SIGTERM};
+    use std::mem;
+
+    unsafe {
+        let child_pid: pid_t = getpid();
+        let parent_pid: pid_t = getppid();
+
+        let intermediate = fork();
+        if intermediate < 0 {
+            return;
+        }
+
+        if intermediate == 0 {
+            // Intermediate process: fork the watcher and exit immediately so the
+            // watcher is re-parented to init/launchd and won't become a zombie.
+            let watcher = fork();
+            if watcher < 0 {
+                libc::_exit(1);
+            }
+            if watcher == 0 {
+                // Watcher process: use kqueue to watch parent_pid and child_pid.
+                let kq = kqueue();
+                if kq == -1 {
+                    libc::_exit(1);
+                }
+
+                let changes: [libc::kevent; 2] = [
+                    libc::kevent {
+                        ident: parent_pid as libc::uintptr_t,
+                        filter: EVFILT_PROC,
+                        flags: EV_ADD | EV_ENABLE,
+                        fflags: NOTE_EXIT,
+                        data: 0,
+                        udata: std::ptr::null_mut(),
+                    },
+                    libc::kevent {
+                        ident: child_pid as libc::uintptr_t,
+                        filter: EVFILT_PROC,
+                        flags: EV_ADD | EV_ENABLE,
+                        fflags: NOTE_EXIT,
+                        data: 0,
+                        udata: std::ptr::null_mut(),
+                    },
+                ];
+
+                let r = kevent(
+                    kq,
+                    changes.as_ptr(),
+                    2,
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null(),
+                );
+                if r == -1 {
+                    close(kq);
+                    libc::_exit(1);
+                }
+
+                loop {
+                    let mut res: libc::kevent = mem::zeroed();
+                    let n = kevent(kq, std::ptr::null(), 0, &mut res, 1, std::ptr::null());
+                    if n <= 0 {
+                        break;
+                    }
+                    if res.ident == parent_pid as libc::uintptr_t {
+                        // Parent exited: terminate the child.
+                        libc::kill(child_pid, SIGTERM);
+                        break;
+                    } else if res.ident == child_pid as libc::uintptr_t {
+                        // Child exited on its own: nothing to do.
+                        break;
+                    }
+                }
+
+                close(kq);
+                libc::_exit(0);
+            } else {
+                libc::_exit(0);
+            }
+        } else {
+            // Original child: reap the intermediate process, then continue to exec.
+            let mut status: c_int = 0;
+            waitpid(intermediate, &mut status, 0);
+        }
+    }
 }
 
 pub fn exit_with_parent() -> Result<(), std::io::Error> {


### PR DESCRIPTION
Implement exit with parent functionality for macOS, by porting the reference implementation in `nbdkit` to Rust.

Fixes #29.