### PR TITLE
Validate mono changesets in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,22 +18,7 @@ concurrency:
 
 jobs:
   validate-changesets:
-    name: Validate changesets
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v4
-      - name: Checkout Mono
-        uses: actions/checkout@v4
-        with:
-          repository: appsignal/mono
-          path: tmp/mono
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-      - name: Validate changesets
-        run: tmp/mono/bin/mono changeset validate
+    uses: ./.github/workflows/validate_changesets.yaml
 
   build:
     name: "cargo build"

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -9,22 +9,7 @@ env:
 
 jobs:
   validate-changesets:
-    name: Validate changesets
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v4
-      - name: Checkout Mono
-        uses: actions/checkout@v4
-        with:
-          repository: appsignal/mono
-          path: tmp/mono
-      - name: Install Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-      - name: Validate changesets
-        run: tmp/mono/bin/mono changeset validate
+    uses: ./.github/workflows/validate_changesets.yaml
 
   build_release:
     name: "Build release artifacts"

--- a/.github/workflows/validate_changesets.yaml
+++ b/.github/workflows/validate_changesets.yaml
@@ -1,0 +1,23 @@
+name: Validate changesets
+
+on:
+  workflow_call:
+
+jobs:
+  validate-changesets:
+    name: Validate changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Checkout Mono
+        uses: actions/checkout@v4
+        with:
+          repository: appsignal/mono
+          path: tmp/mono
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - name: Validate changesets
+        run: tmp/mono/bin/mono changeset validate


### PR DESCRIPTION
## Summary
- Extract the inline `validate-changesets` job into a reusable workflow (`.github/workflows/validate_changesets`)
- Reference the reusable workflow from CI and publish release workflows using `uses:`

## Context
Follows the pattern established in appsignal-wrap for reusable workflows (e.g. `build_release`). See appsignal/appsignal-kubernetes#71 review comment.