### PR TITLE
Assign changelog PR to release actor

### DIFF
--- a/.github/workflows/create_release_from_tag.yml
+++ b/.github/workflows/create_release_from_tag.yml
@@ -27,6 +27,18 @@ jobs:
         run: |
           echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
+      - name: Get publish user from tag
+        run: |
+          TAGGER_NAME="$(git for-each-ref --format='%(taggername)' "refs/tags/${{ env.TAG_NAME }}")"
+          PUBLISH_USER="$(printf '%s' "$TAGGER_NAME" | sed -n 's/^AppSignal release bot (as \(.*\))$/\1/p')"
+
+          if [ -z "$PUBLISH_USER" ]; then
+            echo "Could not determine publish user from tagger name: $TAGGER_NAME" >&2
+            exit 1
+          fi
+
+          echo "PUBLISH_USER=$PUBLISH_USER" >> $GITHUB_ENV
+
       - name: Get changelog contents from tag
         run: |
           # Use sed to remove everything after "-----BEGIN PGP SIGNATURE-----" if it's present
@@ -50,7 +62,7 @@ jobs:
             --arg category "$CHANGELOG_CATEGORY" \
             --arg version "$(echo "${{ env.TAG_NAME }}" | sed 's/^v//')" \
             --arg changelog "$(cat CHANGELOG_TEXT.txt)" \
-            --arg assignee "${{ github.actor }}" \
+            --arg assignee "${{ env.PUBLISH_USER }}" \
             '{ref: "main", inputs: {title: $title, category: $category, version: $version, changelog: $changelog, assignee: $assignee}}')
 
           curl -X POST \


### PR DESCRIPTION
I noticed that changelog PRs would be assigned to Noemi because she set up the workflows initially, so GitHub falls back to that in the absence of a GitHub actor value.

This change explicitly tells the workflows which person has initiated the publish workflow and who should be assigned to the changelog PRs that are created.

[skip changeset]